### PR TITLE
Use string literals when constructing config_vars

### DIFF
--- a/runner/init
+++ b/runner/init
@@ -18,7 +18,7 @@ cd $HOME
 
 mkdir -p .profile.d
 if [[ -f .release ]]; then
-	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=#{v}\"}" > .profile.d/config_vars
+	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts '#{k}=#{v}'}" > .profile.d/config_vars
 fi
 for file in .profile.d/*; do 
 	source $file


### PR DESCRIPTION
This fixes `.profile.d/config_vars: line 2: -Xss512k: command not found` error when given a .release file of:

```
root@ip-10-250-15-201:~/slugrunner# tar xfO /opt/deis/runtime/slugs/player-hawthorn-v6.tar.gz ./.release

---
config_vars:
  PATH: /app/.jdk/bin:/usr/local/bin:/usr/bin:/bin
  JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
  MAVEN_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops 
addons:
  heroku-postgresql:dev
```
