### PR TITLE
Use string literals when constructing config_vars

### DIFF
--- a/runner/init
+++ b/runner/init
@@ -18,7 +18,7 @@ cd $HOME
 
 mkdir -p .profile.d
 if [[ -f .release ]]; then
-	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=#{v}\"}" > .profile.d/config_vars
+	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}='#{v}'\"}" > .profile.d/config_vars
 fi
 for file in .profile.d/*; do 
 	source $file


### PR DESCRIPTION
If there are any spaces in the envvars, the sourcing of `profile.d` scripts will fail with command not found errors.  For example, this fixes `.profile.d/config_vars: line 2: -Xss512k: command not found` when running a Java app.  

With the new quoting:

```
root@67ddd39d9783:/app# cat .profile.d/config_vars 
PATH='/app/.jdk/bin:/usr/local/bin:/usr/bin:/bin'
JAVA_OPTS='-Xmx384m -Xss512k -XX:+UseCompressedOops'
MAVEN_OPTS='-Xmx384m -Xss512k -XX:+UseCompressedOops'
```
