### PR TITLE
Add support for bind-mounting /app

### DIFF
--- a/runner/init
+++ b/runner/init
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-## Load slug from STDIN or URL
+## Load slug from Bind Mount, URL or STDIN
 
 export HOME=/app
 mkdir -p $HOME
 
-if [[ $SLUG_URL ]]; then
+if [[ $(ls -A $HOME) ]]; then
+        true
+elif [[ $SLUG_URL ]]; then
 	curl -s "$SLUG_URL" | tar -xzC $HOME
 	unset SLUG_URL
 else


### PR DESCRIPTION
In the case where the slug is already available (and uncompressed) it can make sense to have slugrunner use a bind mounted /app.  This saves time/cycles on URL download or tar decompression on every container start.
